### PR TITLE
Fix: hotkey intermittently opening drawer

### DIFF
--- a/addons/Asset_Drawer/FileSystem.gd
+++ b/addons/Asset_Drawer/FileSystem.gd
@@ -30,9 +30,8 @@ func _enter_tree() -> void:
 
 #region show hide filesystem
 func _input(event: InputEvent) -> void:
-	if (AssetDrawerShortcut.is_match(event) &&
-	event.is_pressed() &&
-	!event.is_echo()):
+	# Toggle the drawer on shortcut release
+	if AssetDrawerShortcut.is_match(event) and event.is_released() and not event.is_echo():
 		if filesBottom == true:
 			match showing:
 				false:
@@ -48,9 +47,7 @@ func _exit_tree() -> void:
 	remove_tool_menu_item("Files to Bottom")
 	FilesToBottom()
 
-
 func _process(delta: float) -> void:
-	
 	newSize = FileDock.get_window().size
 	
 	# Keeps the file system from being unusable in size


### PR DESCRIPTION
Caused by the press event being sent multiple times in quick succession making the drawer appear to work intermittently depending on the OS / Keyboard repeat interval.

Fixes #13