### PR TITLE
Prevent file tree from being shrunk on load

### DIFF
--- a/addons/Asset_Drawer/FileSystem.gd
+++ b/addons/Asset_Drawer/FileSystem.gd
@@ -28,6 +28,11 @@ func _enter_tree() -> void:
 	await get_tree().create_timer(0.1).timeout
 	FilesToBottom()
 
+	# Prevent file tree from being shrunk on load
+	await get_tree().create_timer(0.1).timeout
+	var file_split_container := FileDock.get_child(3) as SplitContainer
+	file_split_container .split_offset = 175
+
 	# Get shortcut
 	AssetDrawerShortcut = preload("res://addons/Asset_Drawer/AssetDrawerShortcut.tres")
 


### PR DESCRIPTION
This is very minor, but it was a little annoying having the file tree be shrunk to the left every time I opened my project. This is only for the vertical split but I'm assuming the horizontal split isn't supported anyway? At the very least it's broken for me, not that I'd want to use it.